### PR TITLE
feat: Created an intermediate datatype to get around the lack of Functor

### DIFF
--- a/src/Verifier.hs
+++ b/src/Verifier.hs
@@ -1,10 +1,8 @@
 {- HLINT ignore "Use camelCase" -}
 {-# LANGUAGE DataKinds #-}
-{-# LANGUAGE DatatypeContexts #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GADTs #-}
-{-# LANGUAGE KindSignatures #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE TypeApplications #-}


### PR DESCRIPTION
After messing with a few ideas I realized that with the design of hmatrix it’s going to be difficult to have the developer provide us with Matrixes of SDoubles. [You killed my functor](https://www.youtube.com/clip/Ugkxf9NM7c2IA3DhLTIzmZGojZIeF_zgvQN7)

Fortunately I found a work around.

HMatrix provides `fromLists` and `toLists` that will convert back and forth between `[[a]]` and `Matrix a`. It makes sense to represent a Matrix as a List of Lists anyway. So what if we just make the developer just provide `[[a]]` where a is our sensitive values? Unlike the Matrix type we have a way to map without adding any extra instances. 

Internally we can unwrap the sensitive doubles then use hmatrix operations and convert back.

Cons:
Developers don't use the Matrix type from hmatrix directly.
Potentially missing out on some hmatrix functions that we don't need to add sensitivity annotations to.

Pros:
Works.
Don't need to implement a bunch of instances to work with hmatrix (and potentially dangerous ones)
List of Lists seem like a natural way to represent a matrix.