### PR TITLE
(Extensibility) Allow user to parse SensitiveTypes

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -27,6 +27,11 @@ dependencies:
 - template-haskell
 - th-abstraction
 
+default-extensions:
+- ImportQualifiedPost
+- TypeApplications
+- LambdaCase
+
 library:
   source-dirs: src
 

--- a/pbt-sensitivity.cabal
+++ b/pbt-sensitivity.cabal
@@ -43,6 +43,10 @@ library
       Paths_pbt_sensitivity
   hs-source-dirs:
       src
+  default-extensions:
+      ImportQualifiedPost
+      TypeApplications
+      LambdaCase
   build-depends:
       QuickCheck
     , base >=4.7 && <5
@@ -58,6 +62,10 @@ executable pbt-sensitivity-exe
       Paths_pbt_sensitivity
   hs-source-dirs:
       app
+  default-extensions:
+      ImportQualifiedPost
+      TypeApplications
+      LambdaCase
   ghc-options: -threaded -rtsopts -with-rtsopts=-N
   build-depends:
       QuickCheck
@@ -77,6 +85,10 @@ test-suite pbt-sensitivity-test
       Paths_pbt_sensitivity
   hs-source-dirs:
       test
+  default-extensions:
+      ImportQualifiedPost
+      TypeApplications
+      LambdaCase
   ghc-options: -threaded -rtsopts -with-rtsopts=-N
   build-depends:
       QuickCheck


### PR DESCRIPTION
In https://github.com/uvm-plaid/pbt-sensitivity/pull/5 we removed an AST that limited extensibility. Users would have to fork this repo and extend some intermediate AST. The previous PR addressed most of that however we perform pattern matching that may not match on a user's custom data type.

Specifically this bit:
```haskell
  typeToTerm :: Type -> Q SensitiveType
  typeToTerm typ = case typ of
    AppT (AppT (ConT termName) (PromotedT metricName)) s ->
      if termName == ''Sensitivity.SDouble
        then typeToSEnv s
        else fail $ "typeToTerm 2 unhandled case" ++ show termName
    AppT (AppT (AppT (ConT termName) (PromotedT metricName)) innerType) s ->
      -- Container like type
      -- TODO This was the case where we handled List and Matrix
      -- It might be that a user might define something that doesn't have this shape
      -- I think we can potentially make this parsing use a typeclass with a default instance
      typeToSEnv s
    _ -> fail $ "typeToTerm main unhandled case" <> show typ
```

Solution:

* Allow a user to parse from an unparsed Template Haskell AST to a SensitiveType AST. Which is defined as: `type ParseSensitiveType = Type -> Either String SensitiveType`
* Provide a default instance so the user does not need to define a custom parser if not required.


Other work:
* genMainQuickCheck' is the function a user can use if they want to define a custom parser
* genMainQuickCheck (without the tick) uses the default parser. 
