### PR TITLE
feat: Support non-sensitive types

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "haskell.formattingProvider": "fourmolu"
+}

--- a/package.yaml
+++ b/package.yaml
@@ -26,6 +26,7 @@ dependencies:
 - matrix
 - template-haskell
 - th-abstraction
+- safe
 
 default-extensions:
 - ImportQualifiedPost

--- a/pbt-sensitivity.cabal
+++ b/pbt-sensitivity.cabal
@@ -1,6 +1,6 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.35.2.
+-- This file has been generated from package.yaml by hpack version 0.35.1.
 --
 -- see: https://github.com/sol/hpack
 
@@ -51,6 +51,7 @@ library
     , base >=4.7 && <5
     , containers
     , matrix
+    , safe
     , template-haskell
     , th-abstraction
   default-language: Haskell2010
@@ -72,6 +73,7 @@ executable pbt-sensitivity-exe
     , containers
     , matrix
     , pbt-sensitivity
+    , safe
     , template-haskell
     , th-abstraction
   default-language: Haskell2010
@@ -95,6 +97,7 @@ test-suite pbt-sensitivity-test
     , containers
     , matrix
     , pbt-sensitivity
+    , safe
     , template-haskell
     , th-abstraction
   default-language: Haskell2010

--- a/src/AnnotatedExternalLibrary.hs
+++ b/src/AnnotatedExternalLibrary.hs
@@ -11,7 +11,7 @@ import Control.Monad (replicateM)
 import Data.Matrix qualified as Matrix
 import Debug.Trace (trace)
 import Distance
-import Sensitivity (CMetric (..), DPSDoubleMatrixL2, DPSMatrix (DPSMatrix_UNSAFE, unDPSMatrix), NMetric (Diff), SDouble (..), SDoubleMatrixL2, SEnv, SMatrix (SMatrix_UNSAFE, unSMatrix), SPair (P_UNSAFE), type (+++), SList)
+import Sensitivity (CMetric (..), DPSDoubleMatrixL2, DPSMatrix (DPSMatrix_UNSAFE, unDPSMatrix), NMetric (Diff), SDouble (..), SDoubleMatrixL2, SEnv, SMatrix (SMatrix_UNSAFE, unSMatrix), SPair (P_UNSAFE), type (+++), SList, JoinSens)
 import Utils
 
 {- | This Module simulates a developer re-exposing "unsafe" external libraries as solo annotated functions
@@ -33,6 +33,11 @@ unsafe_unsafe_plus_prop x1 y1 x2 y2 =
 -- This is a "developer" who's reexposed it with sensitivity annotations. But is it right? We will test that.
 solo_plus :: SDouble Diff s1 -> SDouble Diff s2 -> SDouble Diff (s1 +++ s2)
 solo_plus a b = D_UNSAFE $ unsafe_plus (unSDouble a) (unSDouble b)
+
+-- This is an example of mixed typed function to show how Solo can handle sensitive and non-sensitive types
+-- TODO come up with an example that's less odd
+solo_mixed_types :: SDouble Diff s1 -> SDouble Diff s2 -> Bool -> SDouble Diff (JoinSens s1 s2)
+solo_mixed_types a b chooseA = D_UNSAFE $ max (unSDouble a) (unSDouble b)
 
 -- This is a "developer" who's reexposed but implemented incorrectly.
 solo_plus_incorrect :: SDouble Diff s1 -> SDouble Diff s2 -> SDouble Diff s1

--- a/src/TH.hs
+++ b/src/TH.hs
@@ -49,9 +49,9 @@ instance Show (SensitiveAST -> SensitiveAST) where
 -- Alias to represent types that are not sensitive for functions with mixed types
 -- It is possible that a user defined sensitive type may not be parsed correctly into a SensitiveAST
 -- In that case the user will need to alter their ParseSensitiveAST function
--- To aid the user all NonSensitiveASTs are printed and the user is instructed to verify any sensitive types
--- are not incorrectly parsed as NonSensitiveASTs
-type NonSensitiveAST = Type
+-- To aid the user all NonSensitiveTypes are printed and the user is instructed to verify any sensitive types
+-- are not incorrectly parsed as NonSensitiveTypes
+type NonSensitiveType = Type
 
 -- Name of sensitivty environment
 -- For example the name of `SDouble Diff s1` is s1
@@ -188,7 +188,7 @@ parseInnerSensitiveAST typ = case typ of
 
 -- Parses Template Haskell AST to a list of simplified ASTs
 -- SDouble Diff s -> SDouble Diff s2 -> SDouble Diff (s1 +++ s2) into a list of ASTs
-parseASTs :: Type -> ParseSensitiveAST -> ([Type], [SensitiveAST])
+parseASTs :: Type -> ParseSensitiveAST -> ([NonSensitiveType], [SensitiveAST])
 parseASTs typ extractSensitiveAST = (reverse unparsedTypes, reverse sensAsts)
  where
   splitTypes = splitArgs (stripForall typ)

--- a/src/TH.hs
+++ b/src/TH.hs
@@ -96,12 +96,14 @@ genProp' extractSensitiveAST functionName = do
       functionNameUnqualified = reverse $ takeWhile (/= '.') $ reverse $ show functionName
       -- The name of the property function we are generating. Named [functionName]_prop
       propName = mkName $ functionNameUnqualified <> "_prop"
+
+  -- Log parsing results
+  when verbose $ liftIO $ putStrLn $ "Parsed types: " <> show typeAsts <> "\n-----"
   unless (null unparsedTypes) do
     liftIO $ putStrLn $ "Warning: The following types were not parsed as sensitive types." <>
       "Please verify they are not sensitive types."
     liftIO $ putStrLn $ "Function: " <> show functionName
     liftIO $ putStrLn $ show (length unparsedTypes) <> " Unparsed Types:\n" <> pprint unparsedTypes <> "\n-----"
-    when verbose $ liftIO $ putStrLn $ "Parsed Input Types: " <> show typeAsts <> "\n-----"
 
   liftIO $ putStr $ show typeAsts
   inputTypeAsts <- maybe (fail noTypeAstsError) pure $ initMay typeAsts -- The input types of the function in AST form

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -4,7 +4,7 @@
 {-# LANGUAGE TemplateHaskell #-}
 {-# OPTIONS_GHC -ddump-splices #-}
 
-import AnnotatedExternalLibrary (add_dependently_typed_matrix_solo, add_matrix_solo, add_pair_solo, solo_plus, solo_plus_incorrect)
+import AnnotatedExternalLibrary (add_dependently_typed_matrix_solo, add_matrix_solo, add_pair_solo, solo_plus, solo_plus_incorrect, solo_mixed_types)
 import GHC.TypeLits (KnownNat)
 import Sensitivity
 import TH (genMainQuickCheck)
@@ -12,7 +12,52 @@ import Test.QuickCheck (quickCheck, withMaxSuccess)
 import Utils
 
 f = add_dependently_typed_matrix_solo @2 @4
-$(genMainQuickCheck "tests" ['solo_plus, 'add_pair_solo, 'f])
+$(genMainQuickCheck "tests" ['solo_plus, 'add_pair_solo, 'f, 'solo_mixed_types])
+
+
+-- TODO get rid of these later
+-- $(do
+--   type_ <- reifyType 'solo_plus
+--   type_' <- resolveTypeSynonyms type_
+--   stringE $ show $ parseASTs type_' defaultParseSensitiveASTs
+-- )
+
+-- $(
+-- let inputAst = (SEnv_ $ mkName "s1")
+--     -- Create 2 arguments with the type t1 s1
+--     firstArgName = (GeneratedArgName $ mkName "s1_a")
+--     secondArgName = (GeneratedArgName $ mkName "s1_b") in
+--     -- This will be the distance of the above two arguments
+--     distanceNameForInput = (GeneratedDistanceName $ mkName "dist_for_s1")
+--     do
+--       statement <- genDistanceStatement firstInputAst distanceNameForFirstInput firstInputArgName secondInputArgName
+--       stringE $ pprint statement
+-- )
+
+-- $(
+-- let inputAst = (SEnv_ $ mkName "s1")
+--     -- Create 2 arguments with the type X that contain the above senv
+--     firstArgName = (GeneratedArgName $ mkName "x1")
+--     secondArgName = (GeneratedArgName $ mkName "x2") in
+--     -- This will be the distance of the above two arguments
+--     distanceNameForInput = (GeneratedDistanceName $ mkName "dist_for_s1")
+--     do
+--       statement <- genDistanceStatement firstInputAst distanceNameForFirstInput firstInputArgName secondInputArgName
+--       stringE $ pprint statement
+-- )
+
+-- $(
+-- let -- Create 2 arguments with the type X and Y
+--     type1Args = [(GeneratedArgName $ mkName "x1"), (GeneratedArgName $ mkName "y1")]
+--     -- Create another 2 arguments with the type X and Y
+--     type2Args = [(GeneratedArgName $ mkName "x2"), (GeneratedArgName $ mkName "y2")]
+--     functionName = 'solo_plus in
+--     do
+--       statement <- genDistanceOutStatement functionName type1Args type2Args
+--       stringE $ pprint statement
+-- )
+
+-- genDistanceStatement (SEnv_ $ mkName "s1") (GeneratedDistanceName $ mkName "dist_for_s1") (GeneratedArgName $ mkName "s1_a") (GeneratedArgName $ mkName "s1_b")
 
 $(genMainQuickCheck "failing_tests" ['add_matrix_solo, 'solo_plus_incorrect])
 

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -14,51 +14,6 @@ import Utils
 f = add_dependently_typed_matrix_solo @2 @4
 $(genMainQuickCheck "tests" ['solo_plus, 'add_pair_solo, 'f, 'solo_mixed_types])
 
-
--- TODO get rid of these later
--- $(do
---   type_ <- reifyType 'solo_plus
---   type_' <- resolveTypeSynonyms type_
---   stringE $ show $ parseASTs type_' defaultParseSensitiveASTs
--- )
-
--- $(
--- let inputAst = (SEnv_ $ mkName "s1")
---     -- Create 2 arguments with the type t1 s1
---     firstArgName = (GeneratedArgName $ mkName "s1_a")
---     secondArgName = (GeneratedArgName $ mkName "s1_b") in
---     -- This will be the distance of the above two arguments
---     distanceNameForInput = (GeneratedDistanceName $ mkName "dist_for_s1")
---     do
---       statement <- genDistanceStatement firstInputAst distanceNameForFirstInput firstInputArgName secondInputArgName
---       stringE $ pprint statement
--- )
-
--- $(
--- let inputAst = (SEnv_ $ mkName "s1")
---     -- Create 2 arguments with the type X that contain the above senv
---     firstArgName = (GeneratedArgName $ mkName "x1")
---     secondArgName = (GeneratedArgName $ mkName "x2") in
---     -- This will be the distance of the above two arguments
---     distanceNameForInput = (GeneratedDistanceName $ mkName "dist_for_s1")
---     do
---       statement <- genDistanceStatement firstInputAst distanceNameForFirstInput firstInputArgName secondInputArgName
---       stringE $ pprint statement
--- )
-
--- $(
--- let -- Create 2 arguments with the type X and Y
---     type1Args = [(GeneratedArgName $ mkName "x1"), (GeneratedArgName $ mkName "y1")]
---     -- Create another 2 arguments with the type X and Y
---     type2Args = [(GeneratedArgName $ mkName "x2"), (GeneratedArgName $ mkName "y2")]
---     functionName = 'solo_plus in
---     do
---       statement <- genDistanceOutStatement functionName type1Args type2Args
---       stringE $ pprint statement
--- )
-
--- genDistanceStatement (SEnv_ $ mkName "s1") (GeneratedDistanceName $ mkName "dist_for_s1") (GeneratedArgName $ mkName "s1_a") (GeneratedArgName $ mkName "s1_b")
-
 $(genMainQuickCheck "failing_tests" ['add_matrix_solo, 'solo_plus_incorrect])
 
 main :: IO ()

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -4,7 +4,7 @@
 {-# LANGUAGE TemplateHaskell #-}
 {-# OPTIONS_GHC -ddump-splices #-}
 
-import AnnotatedExternalLibrary (add_dependently_typed_matrix_solo, add_matrix_solo, add_pair_solo, solo_plus, solo_plus_incorrect, solo_mixed_types)
+import AnnotatedExternalLibrary (add_dependently_typed_matrix_solo, add_matrix_solo, add_pair_solo, solo_plus, solo_plus_incorrect, solo_mixed_types, solo_mixed_types_mult)
 import GHC.TypeLits (KnownNat)
 import Sensitivity
 import TH (genMainQuickCheck)
@@ -12,7 +12,13 @@ import Test.QuickCheck (quickCheck, withMaxSuccess)
 import Utils
 
 f = add_dependently_typed_matrix_solo @2 @4
-$(genMainQuickCheck "tests" ['solo_plus, 'add_pair_solo, 'f, 'solo_mixed_types])
+$(genMainQuickCheck "tests" [
+  -- 'solo_plus,
+  -- 'add_pair_solo,
+  -- 'f,
+  'solo_mixed_types,
+  'solo_mixed_types_mult
+  ])
 
 $(genMainQuickCheck "failing_tests" ['add_matrix_solo, 'solo_plus_incorrect])
 


### PR DESCRIPTION
## Description

This PR supports functions that contain sensitive and non-sensitive types.
Given a function such as:
```haskell
solo_mixed_types :: SDouble Diff s1 -> SDouble Diff s2 -> Bool -> SDouble Diff (JoinSens s1 s2)
solo_mixed_types a b chooseA = D_UNSAFE $ max (unSDouble a) (unSDouble b)
```

Notice that there is two sensitive types and a non-sensitive one. 

Given such a function we generate the following:

```haskell
    solo_mixed_types_test
      = quickCheck ((withMaxSuccess 1000) solo_mixed_types_prop)
    solo_mixed_types_prop
      input1_a3uK
      input1_a3uN
      input2_a3uL
      input2_a3uO
      nonSensitiveInput_a3uQ -- Only a single non-sensitive input is created
      = let 
          distance_a3uM = (Distance.distance input1_a3uK) input2_a3uL
          distance_a3uP = (Distance.distance input1_a3uN) input2_a3uO
          dout_a3uR
            = (Distance.distance
                 (((solo_mixed_types input1_a3uK) input1_a3uN)
                    nonSensitiveInput_a3uQ)) -- This line is new we apply the function to the non-sensitive input as normal
                (((solo_mixed_types input2_a3uL) input2_a3uO)
                   nonSensitiveInput_a3uQ) -- This line is new we apply the function to the non-sensitive input as normal
```

As noted in the generated code. The primary work is to:
1. Generate 1 input for per non-sensitive type (as opposed to 2 per sensitive type)
2. Apply the input on the function

Additionally, the parsing logic has changed. Previously if we encountered an unrecognized type we fail and report that to the user.
Now when we encounter a potentially non-sensitive type we consider it a non-sensitive type and those types are reported to the user. The user is responsible to verify that they are indeed non-sensitive types and if not they should adjust the `ParseSensitiveAST` function.

Notice that `parseASTs` has changed to accommodate that logic:
```
parseASTs :: Type -> ParseSensitiveAST -> Either ParseError [SensitiveAST]
-- vs
parseASTs :: Type -> ParseSensitiveAST -> ([NonSensitiveType], [SensitiveAST]) -- Accumulates NonSensitiveTypes
```
